### PR TITLE
dns: set timeout for entire request

### DIFF
--- a/dns/dnssec.go
+++ b/dns/dnssec.go
@@ -199,9 +199,9 @@ func NewExtResolver() (*ExtResolver, error) {
 		return nil, err
 	}
 	cl := new(dns.Client)
-	cl.Dialer = &net.Dialer{
-		Timeout: 15 * time.Second,
-	}
+	// Set the overall DNS timeout(read, write, connect)to 15secs, this is
+	// high, but we want answers, not speed.
+	cl.Timeout = 15 * time.Second
 	return &ExtResolver{
 		cl:  cl,
 		cfg: cfg,


### PR DESCRIPTION
Prior to this change we only set a connect timeout, which left read and write timeouts at their default of 2secs. I regularly saw timeouts with the default values, especially on reverse lookups. Up the timeout to 15secs for conn, read, & write.