### PR TITLE
add option to display protocol records

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -28,15 +28,19 @@ type Results struct {
 
 	spf     Level
 	spfDesc string
+	spfRec  string
 
 	dmarc     Level
 	dmarcDesc string
+	dmarcRec  string
 
 	mtasts     Level
 	mtastsDesc string
+	mtastsRec  string
 
 	dane     Level
 	daneDesc string
+	daneRec  string
 
 	dnssecMX     Level
 	dnssecMXDesc string
@@ -132,6 +136,7 @@ func evaluateDMARC(domain string, res *Results) error {
 	}
 
 	txt := strings.Join(txts, "")
+	res.dmarcRec = txt
 	rec, err := dmarc.Parse(txt)
 	if err != nil {
 		res.dmarc = LevelInvalid

--- a/dane.go
+++ b/dane.go
@@ -46,6 +46,9 @@ func evaluateDANE(domain string, res *Results) error {
 			res.daneDesc += fmt.Sprintf("no record for %s; ", mx.Host)
 			continue
 		}
+		for _, rec := range recs {
+			res.daneRec += rec.String() + "\n"
+		}
 
 		if !(*active) {
 			continue

--- a/mtasts.go
+++ b/mtasts.go
@@ -40,7 +40,8 @@ func evaluateMTASTS(domain string, res *Results) error {
 		return nil
 	}
 
-	policy, err := mtasts.DownloadPolicy(domain)
+	policy, rawContents, err := mtasts.DownloadPolicy(domain)
+	res.mtastsRec = rawContents
 	if err != nil {
 		res.mtasts = LevelInvalid
 		res.mtastsDesc = "policy fetch error: " + err.Error() + ";"

--- a/mtasts/download.go
+++ b/mtasts/download.go
@@ -14,26 +14,26 @@ var httpClient = &http.Client{
 	Timeout: time.Minute,
 }
 
-func DownloadPolicy(domain string) (*Policy, error) {
+func DownloadPolicy(domain string) (*Policy, string, error) {
 	resp, err := httpClient.Get("https://mta-sts." + domain + "/.well-known/mta-sts.txt")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 
 	// Policies fetched via HTTPS are only valid if the HTTP response code is
 	// 200 (OK).  HTTP 3xx redirects MUST NOT be followed.
 	if resp.StatusCode != 200 {
-		return nil, errors.New("mtasts: HTTP " + resp.Status)
+		return nil, "", errors.New("mtasts: HTTP " + resp.Status)
 	}
 
 	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if contentType != "text/plain" {
-		return nil, errors.New("mtasts: unexpected content type")
+		return nil, "", errors.New("mtasts: unexpected content type")
 	}
 
 	return readPolicy(resp.Body)

--- a/spf.go
+++ b/spf.go
@@ -42,6 +42,7 @@ func evaluateSPF(domain string, res *Results) error {
 }
 
 func evalSPFRecord(txt string, res *Results) error {
+	res.spfRec = txt
 	parts := strings.Split(txt, " ")
 
 	if len(parts) == 0 {


### PR DESCRIPTION
When debugging email setups it can be helpful to view the protocol records, without breaking out dig or other tools. Add an option "protocol" to display retrieved records.